### PR TITLE
WIP: Fix public buckets

### DIFF
--- a/awss3/s3_bucket.go
+++ b/awss3/s3_bucket.go
@@ -15,8 +15,18 @@ import (
 	"golang.org/x/exp/slices"
 )
 
+type S3Client interface {
+	GetBucketLocation(input *s3.GetBucketLocationInput) (*s3.GetBucketLocationOutput, error)
+	CreateBucket(input *s3.CreateBucketInput) (*s3.CreateBucketOutput, error)
+	PutBucketTagging(input *s3.PutBucketTaggingInput) (*s3.PutBucketTaggingOutput, error)
+	PutBucketEncryption(input *s3.PutBucketEncryptionInput) (*s3.PutBucketEncryptionOutput, error)
+	PutBucketPolicy(input *s3.PutBucketPolicyInput) (*s3.PutBucketPolicyOutput, error)
+	DeletePublicAccessBlock(input *s3.DeletePublicAccessBlockInput) (*s3.DeletePublicAccessBlockOutput, error)
+	DeleteBucket(input *s3.DeleteBucketInput) (*s3.DeleteBucketOutput, error)
+}
+
 type S3Bucket struct {
-	s3svc  *s3.S3
+	s3svc  S3Client
 	logger lager.Logger
 }
 
@@ -24,7 +34,7 @@ type bucketPolicyStatement struct {
 	Effect    string   `json:"Effect"`
 	Principal string   `json:"Principal"`
 	Action    []string `json:"Action"`
-	Resource  string   `json:"Resource"`
+	Resource  []string `json:"Resource"`
 }
 
 type bucketPolicy struct {
@@ -33,7 +43,7 @@ type bucketPolicy struct {
 }
 
 func NewS3Bucket(
-	s3svc *s3.S3,
+	s3svc S3Client,
 	logger lager.Logger,
 ) *S3Bucket {
 	return &S3Bucket{
@@ -66,6 +76,8 @@ func (s *S3Bucket) Describe(bucketName, partition string) (BucketDetails, error)
 	return s.buildBucketDetails(bucketName, *region, partition, nil), nil
 }
 
+// Create attempts to create an S3 bucket. If successful, it returns the bucket's location
+// and a nil error. If not, it returns an empty string and an error.
 func (s *S3Bucket) Create(bucketName string, bucketDetails BucketDetails) (string, error) {
 	createBucketInput := s.buildCreateBucketInput(bucketName, bucketDetails)
 	s.logger.Debug("create-bucket", lager.Data{"input": createBucketInput})
@@ -229,11 +241,11 @@ func (s *S3Bucket) Delete(bucketName string, deleteObjects bool) error {
 }
 
 func (s *S3Bucket) deleteBucketContents(bucketName string) error {
-	iter := s3manager.NewDeleteListIterator(s.s3svc, &s3.ListObjectsInput{
+	iter := s3manager.NewDeleteListIterator(s.s3svc.(*s3.S3), &s3.ListObjectsInput{
 		Bucket: aws.String(bucketName),
 	})
 
-	if err := s3manager.NewBatchDeleteWithClient(s.s3svc).Delete(aws.BackgroundContext(), iter); err != nil {
+	if err := s3manager.NewBatchDeleteWithClient(s.s3svc.(*s3.S3)).Delete(aws.BackgroundContext(), iter); err != nil {
 		s.logger.Error("aws-s3-error", err)
 		if awsErr, ok := err.(awserr.Error); ok {
 			return errors.New(awsErr.Code() + ": " + awsErr.Message())

--- a/awss3/s3_bucket.go
+++ b/awss3/s3_bucket.go
@@ -155,6 +155,10 @@ func (s *S3Bucket) Create(bucketName string, bucketDetails BucketDetails) (strin
 // new S3 buckets by default as of April 2023.
 func (s *S3Bucket) checkDeletePublicAccessBlock(bucketDetails BucketDetails, bucketName string) error {
 	var policy bucketPolicy
+	// buckets with no policy are private by default.
+	if bucketDetails.Policy == "" {
+		return nil
+	}
 	err := json.Unmarshal([]byte(bucketDetails.Policy), &policy)
 	if err != nil {
 		s.logger.Error("aws-s3-error", err)

--- a/awss3/s3_bucket_test.go
+++ b/awss3/s3_bucket_test.go
@@ -1,0 +1,100 @@
+package awss3_test
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"code.cloudfoundry.org/lager"
+	"github.com/aws/aws-sdk-go/service/s3"
+
+	"github.com/cloudfoundry-community/s3-broker/awss3"
+)
+
+type MockS3Client struct {
+}
+
+func (c *MockS3Client) GetBucketLocation(input *s3.GetBucketLocationInput) (*s3.GetBucketLocationOutput, error) {
+	return nil, nil
+}
+
+func (c *MockS3Client) CreateBucket(input *s3.CreateBucketInput) (*s3.CreateBucketOutput, error) {
+	location := fmt.Sprint("/", *input.Bucket)
+	return &s3.CreateBucketOutput{
+		Location: &location,
+	}, nil
+}
+
+func (c *MockS3Client) PutBucketTagging(input *s3.PutBucketTaggingInput) (*s3.PutBucketTaggingOutput, error) {
+	return &s3.PutBucketTaggingOutput{}, nil
+}
+
+func (c *MockS3Client) PutBucketEncryption(input *s3.PutBucketEncryptionInput) (*s3.PutBucketEncryptionOutput, error) {
+	return &s3.PutBucketEncryptionOutput{}, nil
+}
+
+func (c *MockS3Client) PutBucketPolicy(input *s3.PutBucketPolicyInput) (*s3.PutBucketPolicyOutput, error) {
+	return &s3.PutBucketPolicyOutput{}, nil
+}
+
+func (c *MockS3Client) DeletePublicAccessBlock(input *s3.DeletePublicAccessBlockInput) (*s3.DeletePublicAccessBlockOutput, error) {
+	return &s3.DeletePublicAccessBlockOutput{}, nil
+}
+
+func (c *MockS3Client) DeleteBucket(input *s3.DeleteBucketInput) (*s3.DeleteBucketOutput, error) {
+	return nil, nil
+}
+
+var publicPolicy = `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": ["s3:GetObject"],
+      "Resource": ["arn:{{.AwsPartition}}:s3:::{{.BucketName}}/*"]
+    }
+  ]
+}`
+
+func TestCreate(t *testing.T) {
+	cases := []struct {
+		Name          string
+		BucketName    string
+		BucketDetails awss3.BucketDetails
+		Location      string
+		Error         error
+	}{
+		{
+			Name:       "basic bucket",
+			BucketName: "b",
+			BucketDetails: awss3.BucketDetails{
+				Policy: "",
+			},
+			Location: "/b",
+			Error:    nil,
+		},
+		{
+			Name:       "public bucket",
+			BucketName: "b",
+			BucketDetails: awss3.BucketDetails{
+				Policy: publicPolicy,
+			},
+			Location: "/b",
+			Error:    nil,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			b := awss3.NewS3Bucket(&MockS3Client{}, lager.NewLogger("test"))
+			location, err := b.Create(tc.BucketName, tc.BucketDetails)
+			if location != tc.Location {
+				t.Errorf("expected location %v, got %v", tc.Location, location)
+			}
+			if !errors.Is(err, tc.Error) {
+				t.Errorf("expected return error %v, got %v", tc.Error, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Changes proposed in this pull request:

Adds a few tests and handles the following conditions:

- Some plans don't specify a policy, taking the default instead
- Resource is specified as a slice in config, match that

There is no CI to run the tests yet, but I ran them locally with `go test ./...`.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the output, which can prevent unintentional leaks of sensitive data.

## Security considerations

None.