### PR TITLE
Match module name to expected binary name

### DIFF
--- a/ci/acceptance/go.mod
+++ b/ci/acceptance/go.mod
@@ -1,4 +1,4 @@
-module acceptance-tests
+module acceptance-test
 
 go 1.20
 


### PR DESCRIPTION
## Changes proposed in this pull request:

The tests fail without this because they expect `go build` to generate a binary named `acceptance-test`.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None.