### PR TITLE
Fix public

### DIFF
--- a/awss3/s3_bucket.go
+++ b/awss3/s3_bucket.go
@@ -193,10 +193,11 @@ func (s *S3Bucket) checkDeletePublicAccessBlock(bucketDetails BucketDetails, buc
 			statement.Principal == publicAccessPolicy.Principal &&
 			slices.Equal(statement.Action, publicAccessPolicy.Action)
 	}) {
-		s.logger.Debug("delete-public-access-block")
-		_, err := s.s3svc.DeletePublicAccessBlock(&s3.DeletePublicAccessBlockInput{
+		deletePublicAccessBlockInput := &s3.DeletePublicAccessBlockInput{
 			Bucket: aws.String(bucketName),
-		})
+		}
+		s.logger.Debug("delete-public-access-block", lager.Data{"input": deletePublicAccessBlockInput})
+		_, err := s.s3svc.DeletePublicAccessBlock(deletePublicAccessBlockInput)
 		if err != nil {
 			s.logger.Error("failed to delete public access block", err)
 			return err

--- a/awss3/s3_bucket.go
+++ b/awss3/s3_bucket.go
@@ -205,6 +205,7 @@ func (s *S3Bucket) checkDeletePublicAccessBlock(bucketDetails BucketDetails, buc
 		}
 	}
 	// sleep to ensure that public access block is deleted before proceeding to put bucket polcy
+	// TODO: figure out if we can make an S3 API call instead of using a sleep statement
 	time.Sleep(1 * time.Second)
 	return nil
 }

--- a/awss3/s3_bucket.go
+++ b/awss3/s3_bucket.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"text/template"
+	"time"
 
 	"code.cloudfoundry.org/lager"
 	"github.com/aws/aws-sdk-go/aws"
@@ -203,6 +204,8 @@ func (s *S3Bucket) checkDeletePublicAccessBlock(bucketDetails BucketDetails, buc
 			return err
 		}
 	}
+	// sleep to ensure that public access block is deleted before proceeding to put bucket polcy
+	time.Sleep(1 * time.Second)
 	return nil
 }
 

--- a/awss3/s3_bucket.go
+++ b/awss3/s3_bucket.go
@@ -150,7 +150,7 @@ func (s *S3Bucket) Create(bucketName string, bucketDetails BucketDetails) (strin
 		s.logger.Debug("put-bucket-policy", lager.Data{"input": putPolicyInput})
 		putPolicyOutput, err := s.s3svc.PutBucketPolicy(putPolicyInput)
 		if err != nil {
-			s.logger.Error("aws-s3-error", err)
+			s.logger.Error("aws-s3-error putting bucket policy", err)
 			if awsErr, ok := err.(awserr.Error); ok {
 				return "", errors.New(awsErr.Code() + ": " + awsErr.Message())
 			}
@@ -197,7 +197,7 @@ func (s *S3Bucket) checkDeletePublicAccessBlock(bucketDetails BucketDetails, buc
 			Bucket: aws.String(bucketName),
 		})
 		if err != nil {
-			s.logger.Error("aws-s3-error", err)
+			s.logger.Error("failed to delete public access block", err)
 			return err
 		}
 	}

--- a/ci/acceptance/run.sh
+++ b/ci/acceptance/run.sh
@@ -9,7 +9,7 @@ cf target -o "${CF_ORGANIZATION}"
 
 cf target -s "${CF_SPACE}"
 
-pushd broker-src-dev/ci/acceptance
+pushd broker-src/ci/acceptance
   cf push ${APP_NAME} -m ${MEMORY_LIMIT:-"128M"} --no-start
 popd
 

--- a/ci/acceptance/run.sh
+++ b/ci/acceptance/run.sh
@@ -9,7 +9,7 @@ cf target -o "${CF_ORGANIZATION}"
 
 cf target -s "${CF_SPACE}"
 
-pushd broker-src/ci/acceptance
+pushd broker-src-dev/ci/acceptance
   cf push ${APP_NAME} -m ${MEMORY_LIMIT:-"128M"} --no-start
 popd
 


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fix typo in the bucket policy statement used to determine if a bucket policy is "public"
- Update unit test to verify that delete public access block logic is called when bucket policy is public
- Add a sleep statement after deleting the public access block to give S3 a chance to recognize that the public access block was deleted before putting the bucket policy. Without this statement, we were still getting intermittent errors from the acceptance tests because the put bucket policy will fail unless the public access block is deleted. See https://ci.fr.cloud.gov/teams/main/pipelines/deploy-go-s3-broker/jobs/acceptance-tests-development/builds/82 vs https://ci.fr.cloud.gov/teams/main/pipelines/deploy-go-s3-broker/jobs/acceptance-tests-development/builds/83

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None
