### PR TITLE
remove log for potentially sensitive information

### DIFF
--- a/awsiam/iam_user.go
+++ b/awsiam/iam_user.go
@@ -131,7 +131,6 @@ func (i *IAMUser) CreateAccessKey(userName string) (string, string, error) {
 		}
 		return "", "", err
 	}
-	i.logger.Debug("create-access-key", lager.Data{"output": createAccessKeyOutput})
 
 	return aws.StringValue(createAccessKeyOutput.AccessKey.AccessKeyId), aws.StringValue(createAccessKeyOutput.AccessKey.SecretAccessKey), nil
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

- remove code that may log potentially sensitive information

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

This change removes code that may accidentally publish sensitive data to logs
