### PR TITLE
Buildpack defaults to Go 1.21, but go.mod specifies 1.21; set 1.22 manually

### DIFF
--- a/ci/acceptance/manifest.yml
+++ b/ci/acceptance/manifest.yml
@@ -5,3 +5,4 @@ applications:
   memory: 128M
   env:
     GOPACKAGENAME: acceptance-test
+    GOVERSION: go1.22


### PR DESCRIPTION
## Changes proposed in this pull request:

- See title

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None.