### PR TITLE
Handle unbind user missing

### DIFF
--- a/broker/broker.go
+++ b/broker/broker.go
@@ -439,24 +439,26 @@ func (b *S3Broker) Unbind(
 		detailsLogKey:    details,
 	})
 
-	accessKeys, err := b.user.ListAccessKeys(b.userName(bindingID))
+	userName := b.userName(bindingID)
+
+	accessKeys, err := b.user.ListAccessKeys(userName)
 	if err != nil {
 		return domain.UnbindSpec{}, err
 	}
 
 	for _, accessKey := range accessKeys {
-		if err := b.user.DeleteAccessKey(b.userName(bindingID), accessKey); err != nil {
+		if err := b.user.DeleteAccessKey(userName, accessKey); err != nil {
 			return domain.UnbindSpec{}, err
 		}
 	}
 
-	userPolicies, err := b.user.ListAttachedUserPolicies(b.userName(bindingID), b.iamPath)
+	userPolicies, err := b.user.ListAttachedUserPolicies(userName, b.iamPath)
 	if err != nil {
 		return domain.UnbindSpec{}, err
 	}
 
 	for _, userPolicy := range userPolicies {
-		if err := b.user.DetachUserPolicy(b.userName(bindingID), userPolicy); err != nil {
+		if err := b.user.DetachUserPolicy(userName, userPolicy); err != nil {
 			return domain.UnbindSpec{}, err
 		}
 
@@ -465,7 +467,7 @@ func (b *S3Broker) Unbind(
 		}
 	}
 
-	if err := b.user.Delete(b.userName(bindingID)); err != nil {
+	if err := b.user.Delete(userName); err != nil {
 		// Do not return error if user was already deleted
 		if awserr, ok := err.(awserr.Error); ok && awserr.Code() == iam.ErrCodeNoSuchEntityException {
 			return domain.UnbindSpec{}, nil

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -470,7 +470,9 @@ func (b *S3Broker) Unbind(
 	if err := b.user.Delete(userName); err != nil {
 		// Do not return error if user was already deleted
 		if awserr, ok := err.(awserr.Error); ok && awserr.Code() == iam.ErrCodeNoSuchEntityException {
-			return domain.UnbindSpec{}, nil
+			return domain.UnbindSpec{
+				IsAsync: false,
+			}, nil
 		}
 		return domain.UnbindSpec{}, err
 	}

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -470,16 +470,12 @@ func (b *S3Broker) Unbind(
 	if err := b.user.Delete(userName); err != nil {
 		// Do not return error if user was already deleted
 		if awserr, ok := err.(awserr.Error); ok && awserr.Code() == iam.ErrCodeNoSuchEntityException {
-			return domain.UnbindSpec{
-				IsAsync: false,
-			}, nil
+			return domain.UnbindSpec{}, nil
 		}
 		return domain.UnbindSpec{}, err
 	}
 
-	return domain.UnbindSpec{
-		IsAsync: false,
-	}, nil
+	return domain.UnbindSpec{}, nil
 }
 
 func (b *S3Broker) LastOperation(

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -428,7 +428,8 @@ func (b *S3Broker) Bind(
 
 func (b *S3Broker) Unbind(
 	context context.Context,
-	instanceID, bindingID string,
+	instanceID,
+	bindingID string,
 	details domain.UnbindDetails,
 	asyncAllowed bool,
 ) (domain.UnbindSpec, error) {

--- a/broker/broker_unit_test.go
+++ b/broker/broker_unit_test.go
@@ -240,23 +240,32 @@ func TestUnbind(t *testing.T) {
 		instanceId    string
 		bindingId     string
 		unbindDetails domain.UnbindDetails
-		user          *mockUser
+		broker        *S3Broker
 	}{
 		"success": {
 			instanceId:    "fake-instance-id",
 			bindingId:     "fake-binding-id",
 			unbindDetails: domain.UnbindDetails{},
-			user:          &mockUser{},
+			broker: &S3Broker{
+				logger: logger,
+				user:   &mockUser{},
+			},
+		},
+		"user was already deleted": {
+			instanceId:    "fake-instance-id",
+			bindingId:     "deleted-1",
+			unbindDetails: domain.UnbindDetails{},
+			broker: &S3Broker{
+				logger:     logger,
+				user:       &mockUser{},
+				userPrefix: "test-user-",
+			},
 		},
 	}
 
 	for name, test := range testCases {
 		t.Run(name, func(t *testing.T) {
-			broker := &S3Broker{
-				user:   test.user,
-				logger: logger,
-			}
-			_, err := broker.Unbind(
+			_, err := test.broker.Unbind(
 				context.Background(),
 				test.instanceId,
 				test.bindingId,

--- a/broker/broker_unit_test.go
+++ b/broker/broker_unit_test.go
@@ -300,7 +300,7 @@ func TestUnbind(t *testing.T) {
 				logger: logger,
 				user:   &mockUser{},
 			},
-			expectUnbindSpec: domain.UnbindSpec{IsAsync: false},
+			expectUnbindSpec: domain.UnbindSpec{},
 		},
 		"user was already deleted": {
 			instanceId:    "fake-instance-id",
@@ -314,7 +314,7 @@ func TestUnbind(t *testing.T) {
 				userPrefix: "test-user",
 			},
 			expectUserAlreadyDeleted: true,
-			expectUnbindSpec:         domain.UnbindSpec{IsAsync: false},
+			expectUnbindSpec:         domain.UnbindSpec{},
 		},
 		"error listing access keys": {
 			instanceId:    "fake-instance-id",

--- a/broker/broker_unit_test.go
+++ b/broker/broker_unit_test.go
@@ -309,7 +309,7 @@ func TestUnbind(t *testing.T) {
 				}
 			}
 			if err != test.expectedErr {
-				t.Fatalf(cmp.Diff(err, test.expectedErr))
+				t.Fatalf("expected error: %s, got: %s", test.expectedErr, err)
 			}
 		})
 	}


### PR DESCRIPTION
## Changes proposed in this pull request:

Fixes https://github.com/cloud-gov/s3-broker/issues/77

- Update broker code to handle case where IAM user was already deleted when trying to unbind credentials
- Add unit tests to cover unbind behavior

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing a bug in the broker unbind behavior
