### PR TITLE
Fix unbind behavior

### DIFF
--- a/awsiam/iam_user.go
+++ b/awsiam/iam_user.go
@@ -87,9 +87,9 @@ func (i *IAMUser) Delete(userName string) error {
 	deleteUserOutput, err := i.iamsvc.DeleteUser(deleteUserInput)
 	if err != nil {
 		i.logger.Error("aws-iam-error", err)
-		if awsErr, ok := err.(awserr.Error); ok {
-			return errors.New(awsErr.Code() + ": " + awsErr.Message())
-		}
+		// if awsErr, ok := err.(awserr.Error); ok {
+		// 	return errors.New(awsErr.Code() + ": " + awsErr.Message())
+		// }
 		return err
 	}
 	i.logger.Debug("delete-user", lager.Data{"output": deleteUserOutput})
@@ -108,9 +108,6 @@ func (i *IAMUser) ListAccessKeys(userName string) ([]string, error) {
 	listAccessKeysOutput, err := i.iamsvc.ListAccessKeys(listAccessKeysInput)
 	if err != nil {
 		i.logger.Error("aws-iam-error", err)
-		if awsErr, ok := err.(awserr.Error); ok {
-			return accessKeys, errors.New(awsErr.Code() + ": " + awsErr.Message())
-		}
 		return accessKeys, err
 	}
 	i.logger.Debug("list-access-keys", lager.Data{"output": listAccessKeysOutput})
@@ -243,9 +240,9 @@ func (i *IAMUser) ListAttachedUserPolicies(userName, iamPath string) ([]string, 
 	listAttachedUserPoliciesOutput, err := i.iamsvc.ListAttachedUserPolicies(listAttachedUserPoliciesInput)
 	if err != nil {
 		i.logger.Error("aws-iam-error", err)
-		if awsErr, ok := err.(awserr.Error); ok {
-			return userPolicies, errors.New(awsErr.Code() + ": " + awsErr.Message())
-		}
+		// if awsErr, ok := err.(awserr.Error); ok {
+		// 	return userPolicies, errors.New(awsErr.Code() + ": " + awsErr.Message())
+		// }
 		return userPolicies, err
 	}
 	i.logger.Debug("list-attached-user-policies", lager.Data{"output": listAttachedUserPoliciesOutput})

--- a/awsiam/iam_user.go
+++ b/awsiam/iam_user.go
@@ -87,9 +87,6 @@ func (i *IAMUser) Delete(userName string) error {
 	deleteUserOutput, err := i.iamsvc.DeleteUser(deleteUserInput)
 	if err != nil {
 		i.logger.Error("aws-iam-error", err)
-		// if awsErr, ok := err.(awserr.Error); ok {
-		// 	return errors.New(awsErr.Code() + ": " + awsErr.Message())
-		// }
 		return err
 	}
 	i.logger.Debug("delete-user", lager.Data{"output": deleteUserOutput})
@@ -240,9 +237,6 @@ func (i *IAMUser) ListAttachedUserPolicies(userName, iamPath string) ([]string, 
 	listAttachedUserPoliciesOutput, err := i.iamsvc.ListAttachedUserPolicies(listAttachedUserPoliciesInput)
 	if err != nil {
 		i.logger.Error("aws-iam-error", err)
-		// if awsErr, ok := err.(awserr.Error); ok {
-		// 	return userPolicies, errors.New(awsErr.Code() + ": " + awsErr.Message())
-		// }
 		return userPolicies, err
 	}
 	i.logger.Debug("list-attached-user-policies", lager.Data{"output": listAttachedUserPoliciesOutput})

--- a/awsiam/iam_user_test.go
+++ b/awsiam/iam_user_test.go
@@ -233,18 +233,6 @@ var _ = Describe("IAM User", func() {
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("operation failed"))
 			})
-
-			Context("and it is an AWS error", func() {
-				BeforeEach(func() {
-					deleteUserError = awserr.New("code", "message", errors.New("operation failed"))
-				})
-
-				It("returns the proper error", func() {
-					err := user.Delete(userName)
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(Equal("code: message"))
-				})
-			})
 		})
 	})
 
@@ -301,18 +289,6 @@ var _ = Describe("IAM User", func() {
 				_, err := user.ListAccessKeys(userName)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("operation failed"))
-			})
-
-			Context("and it is an AWS error", func() {
-				BeforeEach(func() {
-					listAccessKeysError = awserr.New("code", "message", errors.New("operation failed"))
-				})
-
-				It("returns the proper error", func() {
-					_, err := user.ListAccessKeys(userName)
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(Equal("code: message"))
-				})
 			})
 		})
 	})
@@ -665,18 +641,6 @@ var _ = Describe("IAM User", func() {
 				_, err := user.ListAttachedUserPolicies(userName, iamPath)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(Equal("operation failed"))
-			})
-
-			Context("and it is an AWS error", func() {
-				BeforeEach(func() {
-					listAttachedUserPoliciesError = awserr.New("code", "message", errors.New("operation failed"))
-				})
-
-				It("returns the proper error", func() {
-					_, err := user.ListAttachedUserPolicies(userName, iamPath)
-					Expect(err).To(HaveOccurred())
-					Expect(err.Error()).To(Equal("code: message"))
-				})
 			})
 		})
 	})


### PR DESCRIPTION
## Changes proposed in this pull request:

- Update error handling in IAMUser struct so that raw AWS error is returned to calling function, which allows checking the AWS error code to ignore or to return errors as desired

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just fixing broker unbind behavior
