### PR TITLE
Add better logging and tests to Bind method and simplify Bind err cleanup

### DIFF
--- a/awsiam/iam_user.go
+++ b/awsiam/iam_user.go
@@ -39,7 +39,7 @@ func (i *IAMUser) Describe(userName string) (UserDetails, error) {
 
 	getUserOutput, err := i.iamsvc.GetUser(getUserInput)
 	if err != nil {
-		i.logger.Error("aws-iam-error", err)
+		i.logger.Error("get-user.aws-iam-error", err)
 		if awsErr, ok := err.(awserr.Error); ok {
 			return userDetails, errors.New(awsErr.Code() + ": " + awsErr.Message())
 		}
@@ -66,14 +66,15 @@ func (i *IAMUser) Create(
 	i.logger.Debug("create-user", lager.Data{"input": createUserInput})
 
 	createUserOutput, err := i.iamsvc.CreateUser(createUserInput)
+	i.logger.Debug("create-user", lager.Data{"output": createUserOutput})
+
 	if err != nil {
-		i.logger.Error("aws-iam-error", err)
+		i.logger.Error("create-user.aws-iam-error", err)
 		if awsErr, ok := err.(awserr.Error); ok {
 			return "", errors.New(awsErr.Code() + ": " + awsErr.Message())
 		}
 		return "", err
 	}
-	i.logger.Debug("create-user", lager.Data{"output": createUserOutput})
 
 	return aws.StringValue(createUserOutput.User.Arn), nil
 }
@@ -86,7 +87,7 @@ func (i *IAMUser) Delete(userName string) error {
 
 	deleteUserOutput, err := i.iamsvc.DeleteUser(deleteUserInput)
 	if err != nil {
-		i.logger.Error("aws-iam-error", err)
+		i.logger.Error("delete-user.aws-iam-error", err)
 		return err
 	}
 	i.logger.Debug("delete-user", lager.Data{"output": deleteUserOutput})


### PR DESCRIPTION
## Changes proposed in this pull request:

- Previously, one defer with if statements cleaned up resources that were created before the method returned an error. This has been split into three defers which are stacked procedure executes, and each of which has better logging.
- Also, fix a small bug on broker.go:365, in which an error could be sent to the channel twice.
- Refactored part of the test mocks to a more general structure for use with the new tests. Previously, the mocks were more tailor-written to TestUnbind.

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

I checked the newly logged structs and they do not contain credentials. They are using the appropriate log level.