### PR TITLE
Fix error handling

### DIFF
--- a/awss3/s3_bucket.go
+++ b/awss3/s3_bucket.go
@@ -336,6 +336,14 @@ func (s *S3Bucket) handleDeleteError(bucketName string, err error) error {
 			s.logger.Info(fmt.Sprintf("NoSuchBucket: %s", bucketName))
 			return nil
 		}
+		// Get original error
+		// if origErr := awsErr.OrigErr(); origErr != nil {
+		// 	// operate on original error.
+		// 	if isNoSuchBucketError(origErr) {
+		// 		s.logger.Info(fmt.Sprintf("NoSuchBucket: %s", bucketName))
+		// 		return nil
+		// 	}
+		// }
 	}
 	return err
 }


### PR DESCRIPTION
## Changes proposed in this pull request:

Related to https://github.com/cloud-gov/s3-broker/issues/84

- Add logic to ignore NoSuchBucket errors when trying to batch delete files from a bucket. If the bucket was already deleted, then it's fine for the batch file delete operation to ignore the error and continue
- Add/update unit tests to cover new behavior

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

There should be no security considerations, just fixing bug preventing service deletion
