### PR TITLE
improve error handling for batch delete errors

### DIFF
--- a/awss3/s3_bucket.go
+++ b/awss3/s3_bucket.go
@@ -227,7 +227,6 @@ func (s *S3Bucket) Modify(bucketName string, bucketDetails BucketDetails) error 
 }
 
 func (s *S3Bucket) Delete(bucketName string, deleteObjects bool) error {
-
 	deleteBucketInput := &s3.DeleteBucketInput{
 		Bucket: aws.String(bucketName),
 	}
@@ -340,10 +339,12 @@ func handleDeleteError(err error) error {
 func isBatchDeleteNoBucketError(batchErr awserr.Error) bool {
 	origErr := batchErr.OrigErr()
 	if origBatchErrs, origAwsOk := origErr.(s3manager.Errors); origAwsOk {
-		for _, origBatchErr := range origBatchErrs {
-			if origBatchErr.OrigErr != nil {
-				return isNoSuchBucketError(origBatchErr.OrigErr)
-			}
+		if len(origBatchErrs) > 1 {
+			return false
+		}
+		origBatchErr := origBatchErrs[0]
+		if origBatchErr.OrigErr != nil {
+			return isNoSuchBucketError(origBatchErr.OrigErr)
 		}
 	}
 	return false

--- a/awss3/s3_bucket_test.go
+++ b/awss3/s3_bucket_test.go
@@ -261,6 +261,22 @@ func TestIsBatchDeleteNoBucketError(t *testing.T) {
 			},
 		},
 	)
+	batchDeleteNoSuchBucketErr2 := s3manager.NewBatchError(
+		"BatchedDeleteIncomplete",
+		"some objects have failed to be deleted.",
+		[]s3manager.Error{
+			{
+				OrigErr: awserr.NewRequestFailure(awserr.New("OtherError", "this is a random error", nil), 500, "req-1"),
+				Bucket:  aws.String("bucket"),
+				Key:     aws.String("key"),
+			},
+			{
+				OrigErr: awserr.NewRequestFailure(awserr.New("NoSuchBucket", "specified bucket does not exist", nil), 404, "req-1"),
+				Bucket:  aws.String("bucket"),
+				Key:     aws.String("key"),
+			},
+		},
+	)
 	batchDeleteOtherErr := s3manager.NewBatchError(
 		"BatchedDeleteIncomplete",
 		"some objects have failed to be deleted.",
@@ -277,9 +293,13 @@ func TestIsBatchDeleteNoBucketError(t *testing.T) {
 		inputErr                awserr.Error
 		expectIsNoSuchBucketErr bool
 	}{
-		"batch delete NoSuchBucket error, expect true": {
+		"batch delete NoSuchBucket first error, expect true": {
 			inputErr:                batchDeleteNoSuchBucketErr,
 			expectIsNoSuchBucketErr: true,
+		},
+		"batch delete NoSuchBucket second error, expect false": {
+			inputErr:                batchDeleteNoSuchBucketErr2,
+			expectIsNoSuchBucketErr: false,
 		},
 		"batch delete other error, expect error": {
 			inputErr:                batchDeleteOtherErr,


### PR DESCRIPTION
## Changes proposed in this pull request:

- improve error handling for batch delete errors so that only batch delete errors where NoSuchBucket is **the only error** are ignored

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None, just improving error handling
