### PR TITLE
Fix when  IAM user is in the broker but isn't in AWS

### DIFF
--- a/awsiam/iam_user.go
+++ b/awsiam/iam_user.go
@@ -27,8 +27,16 @@ func NewIAMUser(
 	}
 }
 
-// boolean func Exists goes here; only returns True, False, err
 func (i *IAMUser) Exists(userName string) (bool, error) {
+	//Format userName as an AWS string
+	existsUserInput := &iam.GetUserInput{
+		UserName: aws.String(userName),
+	}
+	i.logger.Debug("exists-user", lager.Data{"input": existsUserInput})
+	_, err := i.iamsvc.GetUser(existsUserInput)
+	if err != nil {
+		return false, err
+	}
 	return true, nil
 }
 
@@ -40,11 +48,11 @@ func (i *IAMUser) Describe(userName string) (UserDetails, error) {
 	getUserInput := &iam.GetUserInput{
 		UserName: aws.String(userName),
 	}
-	i.logger.Debug("get-user", lager.Data{"input": getUserInput})
+	i.logger.Debug("describe-user", lager.Data{"input": getUserInput})
 
 	getUserOutput, err := i.iamsvc.GetUser(getUserInput)
 	if err != nil {
-		i.logger.Error("get-user.aws-iam-error", err)
+		i.logger.Error("describe-user.aws-iam-error", err)
 		if awsErr, ok := err.(awserr.Error); ok {
 			return userDetails, errors.New(awsErr.Code() + ": " + awsErr.Message())
 		}

--- a/awsiam/iam_user.go
+++ b/awsiam/iam_user.go
@@ -27,6 +27,11 @@ func NewIAMUser(
 	}
 }
 
+// boolean func Exists goes here; only returns True, False, err
+func (i *IAMUser) Exists(userName string) (bool, error) {
+	return true, nil
+}
+
 func (i *IAMUser) Describe(userName string) (UserDetails, error) {
 	userDetails := UserDetails{
 		UserName: userName,
@@ -52,6 +57,8 @@ func (i *IAMUser) Describe(userName string) (UserDetails, error) {
 
 	return userDetails, nil
 }
+
+// copy above into GET up to line 40, then return iamsve...
 
 func (i *IAMUser) Create(
 	userName,

--- a/awsiam/iam_user.go
+++ b/awsiam/iam_user.go
@@ -40,7 +40,6 @@ func (i *IAMUser) Exists(userName string) (bool, error) {
 				return false, nil
 			}
 		}
-		// FIXME: returning false seems wrong here
 		return false, err
 	}
 	return true, nil

--- a/awsiam/iam_user.go
+++ b/awsiam/iam_user.go
@@ -28,21 +28,19 @@ func NewIAMUser(
 }
 
 func (i *IAMUser) Exists(userName string) (bool, error) {
-	//Format userName as an AWS string
 	existsUserInput := &iam.GetUserInput{
 		UserName: aws.String(userName),
 	}
 	i.logger.Debug("exists-user", lager.Data{"input": existsUserInput})
 	_, err := i.iamsvc.GetUser(existsUserInput)
 	if err != nil {
-		// log the error
 		i.logger.Error("exists-user.aws-iam-error", err)
-		// if an aws error do things
 		if awsErr, ok := err.(awserr.Error); ok {
 			if awsErr.Code() == "NoSuchEntity" {
 				return false, nil
 			}
 		}
+		// FIXME: returning false seems wrong here
 		return false, err
 	}
 	return true, nil
@@ -73,8 +71,6 @@ func (i *IAMUser) Describe(userName string) (UserDetails, error) {
 
 	return userDetails, nil
 }
-
-// copy above into GET up to line 40, then return iamsve...
 
 func (i *IAMUser) Create(
 	userName,

--- a/awsiam/iam_user.go
+++ b/awsiam/iam_user.go
@@ -35,6 +35,14 @@ func (i *IAMUser) Exists(userName string) (bool, error) {
 	i.logger.Debug("exists-user", lager.Data{"input": existsUserInput})
 	_, err := i.iamsvc.GetUser(existsUserInput)
 	if err != nil {
+		// log the error
+		i.logger.Error("exists-user.aws-iam-error", err)
+		// if an aws error do things
+		if awsErr, ok := err.(awserr.Error); ok {
+			if awsErr.Code() == "NoSuchEntity" {
+				return false, nil
+			}
+		}
 		return false, err
 	}
 	return true, nil

--- a/awsiam/iam_user_test.go
+++ b/awsiam/iam_user_test.go
@@ -48,8 +48,20 @@ var _ = Describe("IAM User", func() {
 		user = NewIAMUser(iamsvc, logger)
 	})
 	var _ = Describe("Exists", func() {
-		It("returns false by default", func() {
-			userExistence, err := user.Exists(username)
+		/*		var (
+							userExistence bool
+							//			existsUserError error
+						)
+
+				BeforeEach(func() {
+					userExistence = true
+					//			existsUserError = nil
+				})
+		*/
+
+		It("doesn't error out", func() {
+			userExistence, err := user.Exists(userName)
+			Expect(userExistence).To(BeTrue())
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})

--- a/awsiam/iam_user_test.go
+++ b/awsiam/iam_user_test.go
@@ -87,15 +87,17 @@ var _ = Describe("IAM User", func() {
 			Expect(err).NotTo(HaveOccurred())
 		})
 
-		When("the user doesn't exist", func() {
-			BeforeEach(func() {
-				existsUserError = awserr.New("NoSuchEntity", "user does not exist", errors.New("original error"))
-			})
+		Context("the AWS getUser call returns an error", func() {
+			When("AWS returns NoSuch entity", func() {
+				BeforeEach(func() {
+					existsUserError = awserr.New("NoSuchEntity", "user does not exist", errors.New("original error"))
+				})
 
-			It("is false for an non-existing userName", func() {
-				userExistence, err := user.Exists(userName)
-				Expect(userExistence).To(BeFalse())
-				Expect(err).NotTo(HaveOccurred())
+				It("is false for an non-existing userName", func() {
+					userExistence, err := user.Exists(userName)
+					Expect(userExistence).To(BeFalse())
+					Expect(err).NotTo(HaveOccurred())
+				})
 			})
 		})
 	})

--- a/awsiam/iam_user_test.go
+++ b/awsiam/iam_user_test.go
@@ -48,23 +48,49 @@ var _ = Describe("IAM User", func() {
 		user = NewIAMUser(iamsvc, logger)
 	})
 	var _ = Describe("Exists", func() {
-		/*		var (
-							userExistence bool
-							//			existsUserError error
-						)
+		var (
+			// properUserDetails UserDetails
+			existsUser      *iam.User
+			existsUserInput *iam.GetUserInput
+			existsUserError awserr.Error
+		)
+		BeforeEach(func() {
+			/*
+				properUserDetails = UserDetails{
+					UserName: userName,
+					UserARN:  "user-arn",
+					UserID:   "user-id",
+				}
+			*/
+			existsUser = &iam.User{
+				Arn:    aws.String("user-arn"),
+				UserId: aws.String("user-id"),
+			}
+			existsUserInput = &iam.GetUserInput{
+				UserName: aws.String(userName),
+			}
+			existsUserError = nil
+		})
+		JustBeforeEach(func() {
+			iamsvc.Handlers.Clear()
+			iamCall = func(r *request.Request) {
+				Expect(r.Operation.Name).To(Equal("GetUser"))
+				Expect(r.Params).To(BeAssignableToTypeOf(&iam.GetUserInput{}))
+				Expect(r.Params).To(Equal(existsUserInput))
+				data := r.Data.(*iam.GetUserOutput)
+				data.User = existsUser
+				r.Error = existsUserError
+			}
+			iamsvc.Handlers.Send.PushBack(iamCall)
+		})
 
-				BeforeEach(func() {
-					userExistence = true
-					//			existsUserError = nil
-				})
-		*/
-
-		It("doesn't error out", func() {
+		It("it is true for an existing userName", func() {
 			userExistence, err := user.Exists(userName)
 			Expect(userExistence).To(BeTrue())
 			Expect(err).ToNot(HaveOccurred())
 		})
 	})
+
 	var _ = Describe("Describe", func() {
 		var (
 			properUserDetails UserDetails

--- a/awsiam/iam_user_test.go
+++ b/awsiam/iam_user_test.go
@@ -47,7 +47,12 @@ var _ = Describe("IAM User", func() {
 
 		user = NewIAMUser(iamsvc, logger)
 	})
-
+	var _ = Describe("Exists", func() {
+		It("returns false by default", func() {
+			userExistence, err := user.Exists(username)
+			Expect(err).ToNot(HaveOccurred())
+		})
+	})
 	var _ = Describe("Describe", func() {
 		var (
 			properUserDetails UserDetails

--- a/awsiam/user.go
+++ b/awsiam/user.go
@@ -10,6 +10,7 @@ import (
 )
 
 type User interface {
+	Exists(userName string) (bool, error)
 	Describe(userName string) (UserDetails, error)
 	Create(userName, iamPath string, iamTags []*iam.Tag) (string, error)
 	Delete(userName string) error

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -511,6 +511,16 @@ func (b *S3Broker) Unbind(
 
 	userName := b.userName(bindingID)
 
+	/*
+		exists, err := b.user.Exists(userName)
+		if err != nil {
+			return domain.UnbindSpec{}, err
+		}
+		if !exists {
+			return domain.UnbindSpec{}, nil
+		}
+	*/
+
 	accessKeys, err := b.user.ListAccessKeys(userName)
 	if b.handleUnbindError(err) != nil {
 		return domain.UnbindSpec{}, err

--- a/broker/broker.go
+++ b/broker/broker.go
@@ -511,15 +511,13 @@ func (b *S3Broker) Unbind(
 
 	userName := b.userName(bindingID)
 
-	/*
-		exists, err := b.user.Exists(userName)
-		if err != nil {
-			return domain.UnbindSpec{}, err
-		}
-		if !exists {
-			return domain.UnbindSpec{}, nil
-		}
-	*/
+	exists, err := b.user.Exists(userName)
+	if err != nil {
+		return domain.UnbindSpec{}, err
+	}
+	if !exists {
+		return domain.UnbindSpec{}, nil
+	}
 
 	accessKeys, err := b.user.ListAccessKeys(userName)
 	if b.handleUnbindError(err) != nil {

--- a/broker/broker_unit_test.go
+++ b/broker/broker_unit_test.go
@@ -172,6 +172,10 @@ func (u *mockUser) AttachUserPolicy(userName, policyARN string) error {
 	return nil
 }
 
+func (u *mockUser) Exists(userName string) (bool, error) {
+	return true, nil
+}
+
 func (u *mockUser) Describe(userName string) (awsiam.UserDetails, error) {
 	return awsiam.UserDetails{}, nil
 }
@@ -400,7 +404,6 @@ func TestUnbind(t *testing.T) {
 			},
 			expectUnbindSpec: domain.UnbindSpec{},
 		},
-		// Add NoSuchEntity error on GetUser
 		"NoSuchEntity error when deleting user": {
 			instanceId:    "fake-instance-id",
 			bindingId:     "deleted-1",

--- a/broker/broker_unit_test.go
+++ b/broker/broker_unit_test.go
@@ -400,6 +400,7 @@ func TestUnbind(t *testing.T) {
 			},
 			expectUnbindSpec: domain.UnbindSpec{},
 		},
+		// Add NoSuchEntity error on GetUser
 		"NoSuchEntity error when deleting user": {
 			instanceId:    "fake-instance-id",
 			bindingId:     "deleted-1",


### PR DESCRIPTION
## Changes proposed in this pull request:

- Fix issues when the IAM user is in the broker DB but hasn't actually been created in AWS, see related [ZenDesk issue](https://cloud-gov-new.zendesk.com/agent/tickets/11549): 
- Proposed fix from [Slack](https://gsa-tts.slack.com/archives/C053TPQQEF9/p1745936298953759)
    > at this point,  we could leave the IAM policy as you updated it
make a separate policy statement for GetUser with perms on "arn:aws-us-gov:iam::135676904304:user/cg-s3-*" and update the broker code to do a getUser before delete
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

[Note the any security considerations here, or make note of why there are none]
