### PR TITLE
Reduce chattiness

### DIFF
--- a/ci/acceptance/run.sh
+++ b/ci/acceptance/run.sh
@@ -32,7 +32,7 @@ if [ "${status}" != "200" ]; then
 fi
 
 cf create-service-key ${SERVICE_INSTANCE_NAME} ${SERVICE_INSTANCE_NAME}-service-key
-cf service-key ${SERVICE_INSTANCE_NAME} ${SERVICE_INSTANCE_NAME}-service-key 
+cf service-keys ${SERVICE_INSTANCE_NAME} 
 cf delete-service-key ${SERVICE_INSTANCE_NAME} ${SERVICE_INSTANCE_NAME}-service-key
 
 cf delete -f "${APP_NAME}"


### PR DESCRIPTION
## Changes proposed in this pull request:

-
- Just show service keys existence, not details
-

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Safer, less information
