### PR TITLE
Improve code quality for repo -- fix typo in awss3/s3_bucket.go

### DIFF
--- a/awss3/s3_bucket.go
+++ b/awss3/s3_bucket.go
@@ -222,7 +222,7 @@ func (s *S3Bucket) checkIsPublicAccessBlockDeleted(bucketName string) (bool, err
 }
 
 func (s *S3Bucket) Modify(bucketName string, bucketDetails BucketDetails) error {
-	// TODO Implement modifx
+	// TODO Implement modify
 	return nil
 }
 


### PR DESCRIPTION
## Changes proposed in this pull request:

This PR fixes a small typo in the awss3/s3_bucket.go file

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

None