### PR TITLE
goversion is set in go.mod and not needed here

### DIFF
--- a/ci/acceptance/manifest.yml
+++ b/ci/acceptance/manifest.yml
@@ -5,4 +5,4 @@ applications:
   memory: 128M
   env:
     GOPACKAGENAME: acceptance-test
-    GOVERSION: go1.22
+    


### PR DESCRIPTION
## Changes proposed in this pull request:

- Removes the GOVERSION from the manifest as the version is set in the go.mod. 


## Security considerations

None
